### PR TITLE
fix typo in boolean expression

### DIFF
--- a/src/main/java/com/deviantart/kafka_connect_s3/S3SinkTask.java
+++ b/src/main/java/com/deviantart/kafka_connect_s3/S3SinkTask.java
@@ -48,7 +48,7 @@ public class S3SinkTask extends SinkTask {
   public void start(Map<String, String> props) throws ConnectException {
     config = props;
     String chunkThreshold = config.get("compressed_block_size");
-    if (chunkThreshold == null) {
+    if (chunkThreshold != null) {
       try {
         this.GZIPChunkThreshold = Long.parseLong(chunkThreshold);
       } catch (NumberFormatException nfe) {


### PR DESCRIPTION
The configuration logic appears to want to parse a String to a Long, otherwise applying the default value. However, the boolean expression as written would have non-null user configuration values ignored, and would attempt to parse null values. Seems like a simple typo.