### PR TITLE
Updating aws-java-sdk-s3 to 1.11.295 to support newly added aws s3 regions

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,7 @@ description = ""
 dependencies {
 	compile project(':api')
     compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.1.0'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.10.37'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.295'
 
 	testCompile group: 'junit', name: 'junit', version: '4.12'
 	testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'


### PR DESCRIPTION
Updated to latest version of the s3 java SDK. Tested it and worked well.
This is necessary because newly added s3 regions can't be used with the current sdk version (eg: eu-west-1 throws error)