### PR TITLE
feat: update aws sdk version (1.10.x -> 1.11.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
 }
 
 
-
 task javadocJar(type: Jar, dependsOn: javadoc) {
 	classifier = 'javadoc'
 	from subprojects*.tasks.javadoc.destinationDir

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,7 @@ description = ""
 dependencies {
 	compile project(':api')
     compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.1.0'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.10.37'
+	compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.524'
 
 	testCompile group: 'junit', name: 'junit', version: '4.12'
 	testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
@@ -77,6 +77,7 @@ public class S3SinkTask extends SinkTask {
 			.orElseThrow(() -> new ConnectException("S3 bucket must be configured"));
 		String prefix = configGet("s3.prefix")
 			.orElse("");
+
 		AmazonS3 s3Client = S3.s3client(config);
 
 		s3 = new S3Writer(bucket, prefix, s3Client);

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
@@ -12,6 +12,9 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import org.apache.kafka.common.TopicPartition;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
@@ -37,18 +40,18 @@ import com.spredfast.kafka.connect.s3.json.ChunksIndex;
  */
 public class S3Writer {
 	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-	private final ObjectReader reader = new ObjectMapper().reader(ChunksIndex.class);
+	private final ObjectReader reader = new ObjectMapper().readerFor(ChunksIndex.class);
 	private String keyPrefix;
 	private String bucket;
 	private AmazonS3 s3Client;
 	private TransferManager tm;
 
 	public S3Writer(String bucket, String keyPrefix) {
-		this(bucket, keyPrefix, new AmazonS3Client(new ProfileCredentialsProvider()));
+		this(bucket, keyPrefix, AmazonS3ClientBuilder.standard().withCredentials(new ProfileCredentialsProvider()).build());
 	}
 
 	public S3Writer(String bucket, String keyPrefix, AmazonS3 s3Client) {
-		this(bucket, keyPrefix, s3Client, new TransferManager(s3Client));
+		this(bucket, keyPrefix, s3Client, TransferManagerBuilder.standard().withS3Client(s3Client).build());
 	}
 
 	public S3Writer(String bucket, String keyPrefix, AmazonS3 s3Client, TransferManager tm) {


### PR DESCRIPTION
Bumpl aws-java-sdk-s3 from 1.10.x to 1.11.x to make the connector support new AWS regions and work with some S3 gateways (e.g. minio) that need Signature Version 4.

kafka-connect-65cf98fdb4-rkmbf:kafka-connect Caused by: com.spredfast.shade.amazonaws.AmazonClientException: Unable to verify integrity of data upload. Client calculated content hash (contentMD5: 88MRqk/dLK+Inz4K+K9g0Q== in base 64) didn't match hash (etag: null in hex) calculated by Amazon S3. You may need to delete the data stored in Amazon S3. (metadata.contentMD5: 88MRqk/dLK+Inz4K+K9g0Q==, md5DigestStream: null, bucketName: backups-bucket-minio, key: kafka/operations/2019-03-25/operations-00039-000000000000.gz)
kafka-connect-65cf98fdb4-rkmbf:kafka-connect at com.spredfast.shade.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1402)

Related to #30